### PR TITLE
Fixes #31: Add check for which server was updated before removing

### DIFF
--- a/NotifyMeCI.GUI/Form1.cs
+++ b/NotifyMeCI.GUI/Form1.cs
@@ -385,7 +385,9 @@ namespace NotifyMeCI.GUI
             }
 
             // remove jobs from the list that no longer exist on the server
+            var updatedServers = jobs.Select(j => j.ServerName).Distinct();
             var deadJobs = Jobs.Where(x => !jobs.Any(y => y.Name == x.Name && y.ServerName == x.ServerName));
+            deadJobs = deadJobs.Where(d => updatedServers.Contains(d.ServerName));
             foreach (var job in deadJobs.ToList())
             {
                 Jobs.Remove(job);


### PR DESCRIPTION
jobs from the list

When I added the code to remove jobs that no longer exist on the
server, I naively thought the updates would include jobs from all
servers.  This commit checks which servers are included in the update,
and only removes jobs that no longer exist on those servers.
