### PR TITLE
Move logic to sort jobs to UpdateJobsList method

### DIFF
--- a/NotifyMeCI.GUI/Form1.cs
+++ b/NotifyMeCI.GUI/Form1.cs
@@ -393,6 +393,9 @@ namespace NotifyMeCI.GUI
                 Jobs.Remove(job);
             }
 
+            // sort the jobs
+            Jobs = Jobs.OrderBy(a => a.BuildStatus, new BuildStatusTypeComparer()).ToList();
+
             // show the inform list
             UpdateNotifyIcon(Jobs);
             NotifyOfJobs(informList);
@@ -456,10 +459,7 @@ namespace NotifyMeCI.GUI
             {
                 JobListView.SmallImageList = new ImageList() { ImageSize = new Size(1, 26) };
             }
-
-            // reset ordering
-            jobs = jobs.OrderBy(a => a.BuildStatus, new BuildStatusTypeComparer()).ToList();
-
+            
             // Setup each job in the list
             foreach (var job in jobs)
             {


### PR DESCRIPTION
The logic to sort the list of jobs was in the UpdateJobGui method
which only works with the jobs passed to it as a local variable.
This would sort the jobs displayed, but not the list of jobs saved
at the class level.  When you double click an item in the GUI to
open the job URL, it used the index of the sorted item in the list
to pull the job from the class level variable, which was unsorted.
This would cause the incorrect url to be opened if the sorting rules
changed the order of the items.

This commit moves the sorting logic into the UpdateJobsList and sorts
the class level variable before it passes it to the UpdateJobGui
method.

Resolves Issue #33
